### PR TITLE
Feature/more role dropdown work

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -10,6 +10,7 @@ class RolesController < ApplicationController
       Role.new(user: current_user, min_salary: 20000, min_day_rate: 250)
     ]
     @role_distances = RoleDistance.all
+    @travel_willingness_options = RoleTravelWillingnessOption.all
   end
 
   def update

--- a/app/models/role_travel_willingness_option.rb
+++ b/app/models/role_travel_willingness_option.rb
@@ -1,0 +1,3 @@
+class RoleTravelWillingnessOption < ActiveRecord::Base
+  belongs_to :role
+end

--- a/app/views/roles/_role_details_form.html.erb
+++ b/app/views/roles/_role_details_form.html.erb
@@ -39,8 +39,9 @@
             <select id='permTravelWillingness'
                     ng-model='ctrl.currentRole.permanent_work_travel_willingness'
                     class="form-control">
-              <option value="1">1</option>
-              <option value="2">2</option>
+              <% @travel_willingness_options.each do |option| %>
+                <option value="<%= option.id %>"><%= option.label %></option>
+              <% end %>
             </select>
         </div>
         <div class="form-group">
@@ -112,8 +113,9 @@
             <select id='contractTravelWillingness'
                     ng-model='ctrl.currentRole.contract_work_travel_willingness'
                     class="form-control">
-              <option value="1">1</option>
-              <option value="2">2</option>
+            <% @travel_willingness_options.each do |option| %>
+              <option value="<%= option.id %>"><%= option.label %></option>
+            <% end %>
             </select>
         </div>
         <div class="form-group">

--- a/app/views/roles/_role_details_form.html.erb
+++ b/app/views/roles/_role_details_form.html.erb
@@ -16,10 +16,9 @@
                       class="form-control"
                       type="text" />
               <select ng-model='ctrl.currentRole.permanent_max_travel_distance' class="form-control">
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
+                  <% @role_distances.each do |option| %>
+                    <option value="<%= option.id %>"><%= option.label %></option>
+                  <% end %>
               </select>
             </p>
           </div>
@@ -72,10 +71,9 @@
                       type="text" />
               <select ng-model='ctrl.currentRole.contract_max_travel_distance'
                       class="form-control">
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
+                  <% @role_distances.each do |option| %>
+                    <option value="<%= option.id %>"><%= option.label %></option>
+                  <% end %>
               </select>
             </p>
           </div>

--- a/db/migrate/20151021212045_add_role_travel_willingness_options.rb
+++ b/db/migrate/20151021212045_add_role_travel_willingness_options.rb
@@ -1,0 +1,17 @@
+class AddRoleTravelWillingnessOptions < ActiveRecord::Migration
+  def change
+    create_table :role_travel_willingness_options do |t|
+      t.integer :value
+      t.string :label
+    end
+
+    add_column :roles, :role_travel_willingness_option_id, :integer
+    add_foreign_key :roles, :role_travel_willingness_options
+
+    RoleTravelWillingnessOption.create!(value: 10, label: '0%')
+    RoleTravelWillingnessOption.create!(value: 20, label: '10%')
+    RoleTravelWillingnessOption.create!(value: 25, label: '25%')
+    RoleTravelWillingnessOption.create!(value: 50, label: '50%')
+    RoleTravelWillingnessOption.create!(value: 100, label: '50+%')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151020234546) do
+ActiveRecord::Schema.define(version: 20151021212045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "personal_details", force: :cascade do |t|
     t.string   "name"
@@ -29,6 +30,11 @@ ActiveRecord::Schema.define(version: 20151020234546) do
 
   create_table "role_distances", force: :cascade do |t|
     t.integer "distance"
+    t.string  "label"
+  end
+
+  create_table "role_travel_willingness_options", force: :cascade do |t|
+    t.integer "value"
     t.string  "label"
   end
 
@@ -52,6 +58,7 @@ ActiveRecord::Schema.define(version: 20151020234546) do
     t.integer  "contract_work_travel_willingness"
     t.datetime "contract_available_at"
     t.integer  "role_distance_id"
+    t.integer  "role_travel_willingness_option_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -74,5 +81,6 @@ ActiveRecord::Schema.define(version: 20151020234546) do
 
   add_foreign_key "personal_details", "users"
   add_foreign_key "roles", "role_distances"
+  add_foreign_key "roles", "role_travel_willingness_options"
   add_foreign_key "roles", "users"
 end


### PR DESCRIPTION
- Adding travel willingness as a model too
- Adding the option models to our html form

Realised we need to do some model updates, as currently a `Role` takes one of these options each, whereas we need to separate it out so it has one `:contractor_role_distance_id` and one `:permanent_role_distance_id`. As the user can select different value for each role type. Same goes with the travel willingness.

@carlosmartinez maybe a quick one you'd like to take a look at? Otherwise I'll do it next time
